### PR TITLE
correct spelling allows one

### DIFF
--- a/lib/Template/Perlish.pod
+++ b/lib/Template/Perlish.pod
@@ -326,7 +326,7 @@ Defaults to C<[%>;
 
 =item I<stdout>
 
-boolean value, allows to I<clobber> C<STDOUT> for collecting the
+boolean value, allows one to I<clobber> C<STDOUT> for collecting the
 expansion of a template, or to leave C<STDOUT> untouched.
 
 New option as of release 1.52. Until the previous stable release, this


### PR DESCRIPTION
Lintian prevents Debianisation with this common spelling error allows to --> allows one to.
With this fixed one less patch to apply for the deb-package.